### PR TITLE
Gh-43: Fix typo in fishbowl and address store props changes

### DIFF
--- a/src/fishbowl/fishbowl.py
+++ b/src/fishbowl/fishbowl.py
@@ -245,7 +245,7 @@ class Fishbowl:
                     import_map[module].add(_class)
 
         return [
-            f"from {import_path} import {", ".join(sorted(classes))}" for import_path,
+            f"from {import_path} import {','.join(sorted(classes))}" for import_path,
             classes in import_map.items()
         ]
 

--- a/tests/road-traffic-example/federatedStore.properties
+++ b/tests/road-traffic-example/federatedStore.properties
@@ -14,4 +14,5 @@
 # limitations under the License.
 #
 gaffer.store.class=uk.gov.gchq.gaffer.federatedstore.FederatedStore
+gaffer.store.properties.class=uk.gov.gchq.gaffer.federatedstore.FederatedStoreProperties
 gaffer.cache.service.class=uk.gov.gchq.gaffer.cache.impl.JcsCacheService


### PR DESCRIPTION
Fixes typos in fixbowl and the federated store properties for the 2.2.1 release.