### PR TITLE
Gh-29: Fishbowl should correctly set copyright dates

### DIFF
--- a/src/fishbowl/fishbowl.py
+++ b/src/fishbowl/fishbowl.py
@@ -30,10 +30,10 @@ class Fishbowl:
     def __init__(
         self,
         gaffer_connector: GafferConnector,
-        generated_directory_path: str = "generated"
+        generated_directory_path: str | Path = "generated"
     ):
         self._gaffer_connector = gaffer_connector
-        self.generated_directory_path = generated_directory_path
+        self.generated_directory_path = Path(generated_directory_path)
         print("Generating Python API from REST service...")
         self._generate_library()
         print(
@@ -44,7 +44,8 @@ class Fishbowl:
 
     def _write_to_file(self, file_path: Path, data: str) -> None:
         if data:
-            file_path.unlink()  # removes file
+            if file_path.exists():
+                file_path.unlink()  # removes file
             with open(file_path, "w+") as file:
                 file.write(data)
 

--- a/src/fishbowl/fishbowl.py
+++ b/src/fishbowl/fishbowl.py
@@ -248,7 +248,7 @@ class Fishbowl:
                     import_map[module].add(_class)
 
         return [
-            f"from {import_path} import {','.join(sorted(classes))}" for import_path,
+            f"from {import_path} import {', '.join(sorted(classes))}" for import_path,
             classes in import_map.items()
         ]
 

--- a/src/fishbowl/fishbowl.py
+++ b/src/fishbowl/fishbowl.py
@@ -23,6 +23,7 @@ from gafferpy.gaffer_core import JsonConverter
 from gafferpy.gaffer_types import parse_java_type_to_string
 from collections import defaultdict
 from typing import Any, Callable, Dict, List, Set
+from datetime import datetime
 
 
 class Fishbowl:
@@ -76,6 +77,7 @@ class Fishbowl:
         templates_dir = parent_dir / "templates"
         file_loader = FileSystemLoader(templates_dir)
         self.env = Environment(loader=file_loader)
+        self.env.globals['copyright_years'] = f"2022-{datetime.now().year}"
 
         operations_python = self._generate_operations()
         functions_python = self._generate_transform_functions()

--- a/src/fishbowl/templates/base.py.j2
+++ b/src/fishbowl/templates/base.py.j2
@@ -1,5 +1,5 @@
 #
-# Copyright 2022 Crown Copyright
+# Copyright {{ copyright_years }} Crown Copyright
 #
 # Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Also includes a fix for a bug found while testing fishbowl, plus the fix for #49.

# Related issue

- Resolve #29