### PR TITLE
Gh-59: Add Gremlin endpoints

### DIFF
--- a/.github/workflows/update-gaffer-version.yaml
+++ b/.github/workflows/update-gaffer-version.yaml
@@ -26,12 +26,9 @@ jobs:
 
     - name: Update Gaffer Version
       run: |
-        oldVersion=`sed -n 's/^__version__.*"\(.*\)"$/\1/p' src/__init__.py`
         newVersion=${{ github.event.milestone.title }}
-
-        sed -i'' "s#__version__ = \"$oldVersion\"#__version__ = \"$newVersion\"#g" src/__init__.py
-        sed -i'' "s#__version__ = \"$oldVersion\"#__version__ = \"$newVersion\"#g" src/*/__init__.py
-        sed -i'' "s#release = '$oldVersion'#release = '$newVersion'#g" docs/source/conf.py
+        
+        bash update-versions.sh "${newVersion}"
 
     - name: Update gafferpy
       run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.31.0
+gremlinpython==3.6.2

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ python_requires = ">3.6"
 install_requires = [
     "requests>=2.4.0",
     "gremlinpython>=3.6.2"
-    ]
+]
 extras_require = {
     "dev": [
         "tox",

--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,14 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 python_requires = ">3.6"
-install_requires = []
+install_requires = [
+    "requests>=2.4.0",
+    "gremlinpython>=3.6.2"
+    ]
 extras_require = {
-    "requests": ["requests>=2.4.0"],
     "dev": [
         "tox",
         "pytest",
-        "requests>=2.4.0",
         "sphinx~=7.2.6",
         "sphinx-rtd-theme~=1.3.0"
     ]

--- a/src/gafferpy/gaffer_connector.py
+++ b/src/gafferpy/gaffer_connector.py
@@ -113,7 +113,7 @@ class GafferConnector:
             The result of the query.
         """
         target = "/gremlin/execute"
-        request_headers = { 'accept': 'application/x-ndjson', 'Content-Type': 'text/plain' }
+        request_headers = {'accept': 'application/x-ndjson', 'Content-Type': 'text/plain'}
 
         result = self.client.perform_request(
             method="POST",
@@ -141,7 +141,7 @@ class GafferConnector:
             The result of the query.
         """
         target = "/gremlin/cypher/execute"
-        request_headers = { 'accept': 'application/x-ndjson', 'Content-Type': 'text/plain' }
+        request_headers = {'accept': 'application/x-ndjson', 'Content-Type': 'text/plain'}
 
         result = self.client.perform_request(
             method="POST",
@@ -156,7 +156,6 @@ class GafferConnector:
 
         # Return just raw result
         return result
-
 
     def execute_get(self, operation, headers=None, json_result=False):
         """

--- a/src/gafferpy/gaffer_connector.py
+++ b/src/gafferpy/gaffer_connector.py
@@ -24,7 +24,7 @@ from gafferpy.client import UrllibClient, RequestsClient, PkiClient
 from gafferpy.gaffer_core import ToJson
 from gafferpy.gaffer_config import IsOperationSupported
 from gafferpy.gaffer_operations import OperationChain
-
+from gremlin_python.structure.io.graphsonV3d0 import GraphSONReader
 
 CLIENT_CLASS_NAMES = {
     "urllib": UrllibClient,
@@ -57,6 +57,7 @@ class GafferConnector:
             client_class = CLIENT_CLASS_NAMES[client_class]
 
         self.client = client_class(host, verbose, headers, **kwargs)
+        self.graphson_reader = GraphSONReader()
 
     def execute(self, operation, headers=None):
         """
@@ -99,6 +100,63 @@ class GafferConnector:
             headers,
             json_body
         )
+
+    def execute_gremlin(self, query: str, to_objects=True):
+        """
+        Execute a Gremlin Groovy query using the Gaffer endpoint.
+
+        Args:
+            query: The Gremlin query.
+            to_objects: Should the result be converted to Python objects or left as raw GraphSON.
+
+        Returns:
+            The result of the query.
+        """
+        target = "/gremlin/execute"
+        request_headers = { 'accept': 'application/x-ndjson', 'Content-Type': 'text/plain' }
+
+        result = self.client.perform_request(
+            method="POST",
+            target=target,
+            body=str.encode(query),
+            headers=request_headers
+        )
+
+        # Convert to python using gremlin-python's graphSON reader
+        if to_objects:
+            return self.graphson_reader.to_object(result)
+
+        # Return just raw result
+        return result
+
+    def execute_cypher(self, query: str, to_objects=True):
+        """
+        Execute an Open Cypher query using the Gaffer endpoint.
+
+        Args:
+            query: The Open Cypher query.
+            to_objects: Should the result be converted to Python objects or left as raw GraphSON.
+
+        Returns:
+            The result of the query.
+        """
+        target = "/gremlin/cypher/execute"
+        request_headers = { 'accept': 'application/x-ndjson', 'Content-Type': 'text/plain' }
+
+        result = self.client.perform_request(
+            method="POST",
+            target=target,
+            body=str.encode(query),
+            headers=request_headers
+        )
+
+        # Convert to python using gremlin-python's graphSON reader
+        if to_objects:
+            return self.graphson_reader.to_object(result)
+
+        # Return just raw result
+        return result
+
 
     def execute_get(self, operation, headers=None, json_result=False):
         """

--- a/update-versions.sh
+++ b/update-versions.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2024 Crown Copyright
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ -z "${1}" ]; then
+  echo "Missing version argument"
+  exit 1
+fi
+
+# Upadate all the init python files
+while read -r FILE
+do
+  sed -ri "s/(^__version__ = \")(.*)/\1${1}\"/" "${FILE}"
+done < <(find . -type f -name "__init__.py")
+
+# Update the docs
+sed -ri "s/(^release = \")(.*)/\1${1}\"/" docs/source/conf.py


### PR DESCRIPTION
Adds support for the Gremlin endpoints in gaffer 2.3.1 making it easy to query them via a function. Also simplified the version updating with a simple script.

# Related issue

- Resolve #59