### PR TITLE
Fix possible memory leak

### DIFF
--- a/src/gafferpy/gaffer_config.py
+++ b/src/gafferpy/gaffer_config.py
@@ -14,13 +14,14 @@
 # limitations under the License.
 #
 
-""" 
-This module contains Python copies of Gaffer config java classes 
+"""
+This module contains Python copies of Gaffer config java classes
 """
 
 import inspect
 import sys
 from gafferpy.gaffer_core import JsonConverter
+
 
 class GetGraph:
     def __init__(self, _url=""):
@@ -29,13 +30,17 @@ class GetGraph:
     def get_url(self):
         return self._url
 
+
 # Import generated config implementations from fishbowl
 from gafferpy.generated_api.config import *
 
 # Add an alternative name for GetFilterFunctions
+
+
 class GetClassFilterFunctions(GetFilterFunctions):
     def __init__(self, class_name=""):
         super().__init__(class_name)
+
 
 class IsOperationSupported:
     def __init__(self, operation=None):
@@ -44,20 +49,23 @@ class IsOperationSupported:
     def get_operation(self):
         return self.operation
 
+
 def cleanup_config_json_map():
     """Clear existing mappings to avoid memory bloat."""
     JsonConverter.GENERIC_JSON_CONVERTERS.clear()
     JsonConverter.CLASS_MAP.clear()
 
+
 def load_config_json_map():
     """Load configuration class mappings and clear previous ones."""
     # Clear existing mappings to avoid memory bloat
     cleanup_config_json_map()
-    
+
     for name, class_obj in inspect.getmembers(sys.modules[__name__], inspect.isclass):
         if hasattr(class_obj, "CLASS"):
             JsonConverter.GENERIC_JSON_CONVERTERS[class_obj.CLASS] = \
                 lambda obj, class_obj=class_obj: class_obj(**obj)
             JsonConverter.CLASS_MAP[class_obj.CLASS] = class_obj
+
 
 load_config_json_map()

--- a/src/gafferpy/gaffer_config.py
+++ b/src/gafferpy/gaffer_config.py
@@ -14,14 +14,13 @@
 # limitations under the License.
 #
 
+""" 
+This module contains Python copies of Gaffer config java classes 
 """
-This module contains Python copies of Gaffer config java classes
-"""
+
 import inspect
 import sys
-
 from gafferpy.gaffer_core import JsonConverter
-
 
 class GetGraph:
     def __init__(self, _url=""):
@@ -30,17 +29,13 @@ class GetGraph:
     def get_url(self):
         return self._url
 
-
 # Import generated config implementations from fishbowl
 from gafferpy.generated_api.config import *
 
 # Add an alternative name for GetFilterFunctions
-
-
 class GetClassFilterFunctions(GetFilterFunctions):
     def __init__(self, class_name=""):
         super().__init__(class_name)
-
 
 class IsOperationSupported:
     def __init__(self, operation=None):
@@ -49,14 +44,20 @@ class IsOperationSupported:
     def get_operation(self):
         return self.operation
 
+def cleanup_config_json_map():
+    """Clear existing mappings to avoid memory bloat."""
+    JsonConverter.GENERIC_JSON_CONVERTERS.clear()
+    JsonConverter.CLASS_MAP.clear()
 
 def load_config_json_map():
-    for name, class_obj in inspect.getmembers(
-            sys.modules[__name__], inspect.isclass):
+    """Load configuration class mappings and clear previous ones."""
+    # Clear existing mappings to avoid memory bloat
+    cleanup_config_json_map()
+    
+    for name, class_obj in inspect.getmembers(sys.modules[__name__], inspect.isclass):
         if hasattr(class_obj, "CLASS"):
             JsonConverter.GENERIC_JSON_CONVERTERS[class_obj.CLASS] = \
                 lambda obj, class_obj=class_obj: class_obj(**obj)
             JsonConverter.CLASS_MAP[class_obj.CLASS] = class_obj
-
 
 load_config_json_map()


### PR DESCRIPTION
Added a cleanup_config_json_map() function that clears the GENERIC_JSON_CONVERTERS and CLASS_MAP dictionaries before loading new configurations. This prevents memory bloat by ensuring old class mappings are removed each time load_config_json_map() is called.